### PR TITLE
button-card: more accessible long emoji names

### DIFF
--- a/src/app/_components/emoji-card/button-card.tsx
+++ b/src/app/_components/emoji-card/button-card.tsx
@@ -111,7 +111,7 @@ export function ButtonCard({ id, name, src: _src, createdAt, alwaysShowDownloadB
         </div>
       )}
 
-      <p className="font-mono text-sm truncate">:{name}:</p>
+      <p className="font-mono text-sm truncate" title={name}>:{name}:</p>
 
       <button
         className={cn(


### PR DESCRIPTION
Use the title attribute to make long emoji names perceptible via hover or long press interactions.

![image](https://github.com/Pondorasti/emojis/assets/11449340/f0b866d6-bdb0-4503-872d-7f685980f531)