### PR TITLE
Rename WEBHOOK_SECRET to API_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 REPLICATE_API_TOKEN=
 
 ## Generate a random secret for the webhook: https://generate-secret.vercel.app/32
-WEBHOOK_SECRET=
+API_SECRET=
 
 ## Forward Requests Locally (local dev)
 NGROK_URL=


### PR DESCRIPTION
I couldn't find any usage of `WEBHOOK_SECRET`, but `API_SECRET` is required in other places and is missing from env.sample.